### PR TITLE
Add activity feed API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR

This pull request introduces a new server.js file for the graphite-demo project. The server.js file sets up an express server and fake activity feed data.

### What changed?

A new file called server.js was added to the graphite-demo directory. The new file includes code to setup an express server and to return fake activity feed data on a GET request to '/feed'.

### How to test?

1. Navigate to the graphite-demo directory.
2. Run the command 'node server.js'.
3. Use a tool like curl or Postman to send a GET request to 'http://localhost:3000/feed'. You should see the fake activity feed data in the response.

### Why make this change?

This change was made to setup a basic server for the graphite-demo project and to provide fake activity feed data for development and testing purposes.

---

