### PR TITLE
Add frontend for search

### DIFF
--- a/graphite-demo/frontend.jsx
+++ b/graphite-demo/frontend.jsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+
+const TaskSearch = () => {
+  const [tasks, setTasks] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/search?query=${encodeURIComponent(searchQuery)}`)
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        return response.json();
+      })
+      .then(data => {
+        setTasks(data);
+        setLoading(false);
+      })
+      .catch(error => {
+        setError(error.message);
+        setLoading(false);
+      });
+  }, [searchQuery]); // Depend on searchQuery
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  return (
+    <div>
+      <h2>Task Search</h2>
+      <input
+        type="text"
+        placeholder="Search tasks..."
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+      />
+      <ul>
+        {tasks.map(task => (
+          <li key={task.id}>
+            <p>{task.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default TaskSearch;


### PR DESCRIPTION
### TL;DR
This PR introduces a brand new TaskSearch component into the Graphite-Demo's frontend.

### What changed?
A React-based TaskSearch component has been added, which contains an input field for searching through tasks as well as task listing. It has also integrated an API call to fetch tasks based on a search query and handles loading, error, and data state.

### How to test?
Pull the changes into your local, run the frontend and use the TaskSearch component to search for tasks.

### Why make this change?
This addition enhances the user experience by enabling a quick search through tasks.

---

